### PR TITLE
fixes multiple elements found error

### DIFF
--- a/src/extract-kindle-book.ts
+++ b/src/extract-kindle-book.ts
@@ -167,7 +167,7 @@ async function main() {
   }
 
   async function getPageNav() {
-    const footerText = await page.locator('ion-footer ion-title').textContent()
+    const footerText = await page.locator('ion-footer ion-title').first().textContent()
     return parsePageNav(footerText)
   }
 


### PR DESCRIPTION
- get first element when multiple 
`locator.textContent: Error: strict mode violation: locator('ion-footer ion-title') resolved to 2 elements`
<img width="1245" alt="Screenshot 2024-10-09 at 11 03 11 PM" src="https://github.com/user-attachments/assets/42aaa0e1-d749-4902-8f91-7174cb89e0c3">
