### PR TITLE
fix: support location-based books and handle updated Kindle Cloud Reader UI

### DIFF
--- a/src/extract-kindle-book.ts
+++ b/src/extract-kindle-book.ts
@@ -336,21 +336,52 @@ async function main() {
   }
 
   async function goToPage(pageNumber: number) {
-    await page.locator('#reader-header').hover({ force: true })
-    await delay(200)
-    await page.locator('ion-button[aria-label="Reader menu"]').click()
-    await delay(500)
-    await page
-      .locator('ion-item[role="listitem"]', { hasText: 'Go to Page' })
-      .click()
-    await page
-      .locator('ion-modal input[placeholder="page number"]')
-      .fill(`${pageNumber}`)
-    // await page.locator('ion-modal button', { hasText: 'Go' }).click()
-    await page
-      .locator('ion-modal ion-button[item-i-d="go-to-modal-go-button"]')
-      .click()
-    await delay(500)
+    try {
+      await page.locator('#reader-header').hover({ force: true })
+      await delay(200)
+      // Open the three-dot menu (top-right)
+      const menuButton = page
+        .locator('ion-button[aria-label="Reader menu"]')
+        .or(page.locator('button[aria-label="Reader menu"]'))
+        .or(page.locator('#reader-header button').last())
+      await menuButton.first().click({ timeout: 5000 })
+      await delay(500)
+      // Try "Go to Location" (new UI) or "Go to Page" (old UI)
+      const goToItem = page
+        .locator('ion-item', { hasText: /go to (location|page)/i })
+        .or(
+          page.locator('[role="listitem"]', {
+            hasText: /go to (location|page)/i
+          })
+        )
+        .or(page.getByText(/go to (location|page)/i))
+      await goToItem.first().click({ timeout: 5000 })
+      await delay(300)
+      // Fill in the location/page input
+      const pageInput = page
+        .locator('ion-modal input')
+        .or(page.locator('input[placeholder*="page"]'))
+        .or(page.locator('input[placeholder*="location"]'))
+      await pageInput.first().fill(`${pageNumber}`)
+      // Click Go button
+      const goButton = page
+        .locator('ion-modal ion-button', { hasText: /^go$/i })
+        .or(page.locator('ion-modal button', { hasText: /^go$/i }))
+        .or(
+          page.locator('ion-modal ion-button[item-i-d="go-to-modal-go-button"]')
+        )
+      await goButton.first().click({ timeout: 5000 })
+      await delay(500)
+    } catch (err) {
+      console.warn(
+        `goToPage(${pageNumber}) failed:`,
+        (err as Error).message?.slice(0, 100)
+      )
+      await page.keyboard.press('Escape')
+      await delay(200)
+      await page.keyboard.press('Escape')
+      await delay(200)
+    }
   }
 
   async function getPageNav() {
@@ -485,12 +516,16 @@ async function main() {
   // Loop through each page of the book
   do {
     const pageNav = await getPageNav()
+    const currentPage = pageNav?.page ?? pageNav?.location
 
-    if (pageNav?.page === undefined) {
+    if (currentPage === undefined) {
       break
     }
 
-    if (pageNav.page > result.nav.totalNumContentPages) {
+    if (
+      pageNav?.page !== undefined &&
+      pageNav.page > result.nav.totalNumContentPages
+    ) {
       break
     }
 
@@ -524,7 +559,7 @@ async function main() {
 
       assert(
         blob,
-        `no blob found for src: ${src} (index ${index}; page ${pageNav.page})`
+        `no blob found for src: ${src} (index ${index}; page ${currentPage})`
       )
 
       const rawRenderedImage = Buffer.from(blob.base64, 'base64')
@@ -545,21 +580,21 @@ async function main() {
 
     assert(
       renderedPageImageBuffer,
-      `no buffer found for src: ${src} (index ${index}; page ${pageNav.page})`
+      `no buffer found for src: ${src} (index ${index}; page ${currentPage})`
     )
 
     const screenshotPath = path.join(
       pageScreenshotsDir,
       `${index}`.padStart(pageNumberPaddingAmount, '0') +
         '-' +
-        `${pageNav.page}`.padStart(pageNumberPaddingAmount, '0') +
+        `${currentPage}`.padStart(pageNumberPaddingAmount, '0') +
         '.png'
     )
 
     await fs.writeFile(screenshotPath, renderedPageImageBuffer)
     const pageChunk = {
       index,
-      page: pageNav.page,
+      page: currentPage,
       screenshot: screenshotPath
     }
     result.pages.push(pageChunk)
@@ -623,8 +658,11 @@ async function main() {
 
   if (initialPageNav?.page !== undefined) {
     console.warn(`resetting back to initial page ${initialPageNav.page}...`)
-    // Reset back to the initial page
-    await goToPage(initialPageNav.page)
+    try {
+      await goToPage(initialPageNav.page)
+    } catch {
+      console.warn('Failed to reset to initial page, continuing...')
+    }
   }
 
   await context.close()


### PR DESCRIPTION
## Summary

Two bugs that prevent extraction from working on a significant number of Kindle books:

1. **Location-based books produce 0 pages** — `parsePageNav()` in `playwright-utils.ts` already handles the `"Location X of Y"` footer format, correctly returning `{ location, total }`. However, the main extraction loop in `extract-kindle-book.ts` only checks `pageNav?.page`, which is `undefined` for location-based books. This triggers the `break` on the very first iteration, producing an empty result with 0 captured pages.

2. **`goToPage()` crashes on current Kindle Cloud Reader** — Amazon renamed the menu item from "Go to Page" to "Go to Location" and changed the underlying element structure. The hardcoded selectors (`ion-item[role="listitem"]` with `hasText: 'Go to Page'`, `input[placeholder="page number"]`, `ion-button[item-i-d="go-to-modal-go-button"]`) all fail to match, causing a timeout that kills the extraction before any pages are captured.

## Changes

### Location-based book support (main extraction loop)

- Added `const currentPage = pageNav?.page ?? pageNav?.location` to fall back to location when page number is undefined
- Scoped the `totalNumContentPages` bounds check to only apply when `pageNav.page` is defined — location-based books don't have a meaningful page-to-content-page mapping, so the original `pageNav.page > totalNumContentPages` check would never fire anyway (it was the `pageNav?.page === undefined` check above it that caused the early exit)
- Updated all downstream references (`screenshotPath`, `pageChunk`, assertion messages) to use `currentPage` instead of `pageNav.page`

### Resilient `goToPage()` navigation

- Broadened menu button selector with `.or()` fallbacks for both `ion-button` and plain `button` elements
- Changed menu item matching from exact `'Go to Page'` string to regex `/go to (location|page)/i` to handle both old and new Kindle Cloud Reader UI
- Added fallback selectors for the page/location input field (`placeholder*="page"` and `placeholder*="location"`)
- Added fallback selectors for the Go button (text match + legacy `item-i-d` attribute)
- Wrapped the entire function in try/catch — on failure, dismisses any open modals via Escape keypresses and logs a warning instead of crashing the entire extraction
- Wrapped the end-of-extraction `goToPage(initialPageNav.page)` reset in try/catch to prevent a crash after all pages have already been successfully captured

## Reproduction

1. Open any Kindle book that displays "Location X of Y" in the footer (rather than "Page X of Y") — this is common for many self-published and KDP titles
2. Run `npx tsx src/extract-kindle-book.ts`
3. Extraction completes instantly with 0 pages captured, because `parsePageNav()` returns `{ location: X, total: Y }` (no `.page` property), and the loop immediately breaks on `pageNav?.page === undefined`
4. After this fix, the same book correctly captures all pages via location-based navigation

## Related issues

- Partially addresses #14 — same class of selector breakage from Kindle Cloud Reader UI updates
- Partially addresses #6 — the try/catch on the end-of-extraction `goToPage()` call prevents the "target page closed" crash that occurs when the browser context is closing

## Known limitations

The downstream export scripts (`export-book-markdown.ts`, `export-book-pdf.ts`, `export-book-audio.ts`) use `tocItem.page` and `content.findIndex((c) => c.page >= nextTocItem.page!)` to map chapters to content chunks. For location-based books, the `PageChunk.page` field now contains location numbers rather than page numbers, which may cause chapter boundary mismatches in exports. This is a pre-existing limitation (these scripts couldn't work at all before since extraction produced 0 pages) and would be best addressed in a follow-up PR.

## Validated

- [x] Tested on a location-based book — 181 page screenshots captured successfully
- [x] `goToPage()` gracefully recovers when selectors don't match (Escape key dismisses modals)
- [x] Full pipeline works end-to-end: extraction → transcription (GPT-4.1-mini) → markdown export
- [x] Passes `prettier` and `eslint` (pre-commit hooks ran successfully)