### PR TITLE
fix: handle Kindle reader UI and API changes

### DIFF
--- a/src/export-book-audio.ts
+++ b/src/export-book-audio.ts
@@ -58,7 +58,6 @@ async function main() {
   const metadata = await readJsonFile<BookMetadata>(
     path.join(outDir, 'metadata.json')
   )
-  assert(metadata.meta, 'invalid book metadata: missing meta')
   assert(metadata.toc?.length, 'invalid book metadata: missing toc')
 
   // TTS engine configuration
@@ -91,8 +90,8 @@ async function main() {
   const openai = ttsEngine === 'openai' ? new OpenAIClient() : undefined
   const maxCharactersPerAudioBatch = ttsEngine === 'openai' ? 4096 : 3000
 
-  const title = metadata.meta.title
-  const authors = metadata.meta.authorList
+  const title = metadata.meta?.title || 'Unknown Title'
+  const authors = metadata.meta?.authorList || ['Unknown Author']
 
   const configDirHash = hashObject({
     ttsEngine,

--- a/src/export-book-markdown.ts
+++ b/src/export-book-markdown.ts
@@ -19,11 +19,10 @@ async function main() {
     path.join(outDir, 'metadata.json')
   )
   assert(content.length, 'no book content found')
-  assert(metadata.meta, 'invalid book metadata: missing meta')
   assert(metadata.toc?.length, 'invalid book metadata: missing toc')
 
-  const title = metadata.meta.title
-  const authors = metadata.meta.authorList
+  const title = metadata.meta?.title || 'Unknown Title'
+  const authors = metadata.meta?.authorList || ['Unknown Author']
 
   let lastTocItemIndex = 0
   for (let i = 0, index = 0; i < metadata.toc.length - 1; i++) {

--- a/src/export-book-pdf.ts
+++ b/src/export-book-pdf.ts
@@ -22,11 +22,10 @@ async function main() {
     await fsp.readFile(path.join(outDir, 'metadata.json'), 'utf8')
   ) as BookMetadata
   assert(content.length, 'no book content found')
-  assert(metadata.meta, 'invalid book metadata: missing meta')
   assert(metadata.toc?.length, 'invalid book metadata: missing toc')
 
-  const title = metadata.meta.title
-  const authors = metadata.meta.authorList
+  const title = metadata.meta?.title || 'Unknown Title'
+  const authors = metadata.meta?.authorList || ['Unknown Author']
 
   const doc = new PDFDocument({
     autoFirstPage: true,

--- a/src/extract-kindle-book.ts
+++ b/src/extract-kindle-book.ts
@@ -189,6 +189,13 @@ async function main() {
           if (metadata) {
             result.nav.startPosition = metadata.firstPositionId
             result.nav.endPosition = metadata.lastPositionId
+
+            if (!result.meta) {
+              result.meta = {
+                title: metadata.bookTitle,
+                authorList: metadata.authors
+              } as any
+            }
           }
 
           const rawToc = await tryReadJsonFile<AmazonRenderToc>(
@@ -440,12 +447,16 @@ async function main() {
 
   // At this point, we should have recorded all the base book metadata from the
   // initial network requests.
-  assert(result.info, 'expected book info to be initialized')
-  assert(result.meta, 'expected book meta to be initialized')
+  if (!result.info) {
+    console.warn('book info was not initialized from network requests (this is normal for newer Kindle readers)')
+  }
+  if (!result.meta) {
+    console.warn('book meta was not initialized from network requests (this is normal for newer Kindle readers)')
+  }
   assert(result.toc?.length, 'expected book toc to be initialized')
   assert(result.locationMap, 'expected book location map to be initialized')
 
-  result.nav.startContentPosition = result.meta.startPosition
+  result.nav.startContentPosition = result.meta?.startPosition ?? result.nav.startPosition
   result.nav.totalNumPages = result.locationMap.navigationUnit.reduce(
     (acc, navUnit) => {
       return Math.max(acc, navUnit.page ?? -1)
@@ -609,8 +620,8 @@ async function main() {
         break
       }
 
-      if (++retries >= 30) {
-        console.warn('unable to navigate to next page; breaking...', pageNav)
+      if (++retries >= 3) {
+        console.warn('unable to navigate to next page (likely reached the end); breaking...', pageNav)
         done = true
         break
       }


### PR DESCRIPTION
- Relax strict metadata assertions as Amazon no longer provides the old metadata payload
- Extract title and author from the rendered TAR metadata instead
- Reduce navigation retries to prevent getting stuck infinitely at the end of the book