### PR TITLE
feat: name exported files by author/title instead of generic book.*

### DIFF
--- a/src/export-book-audio.ts
+++ b/src/export-book-audio.ts
@@ -15,6 +15,7 @@ import {
   assert,
   ffmpegOnProgress,
   fileExists,
+  getBookFilenameBase,
   getEnv,
   hashObject,
   readJsonFile
@@ -254,7 +255,10 @@ ${text}`.split('\n\n')
     .map((a) => `file ${path.basename(a.audioFilePath)}`)
     .join('\n')
   await fs.writeFile(audioConcatInputFilePath, audioConcatInput)
-  const audiobookOutputFilePath = path.join(ttsOutDir, 'audiobook.mp3')
+  const audiobookOutputFilePath = path.join(
+    ttsOutDir,
+    `${getBookFilenameBase(metadata.meta)}.mp3`
+  )
 
   const expectedDurationMs =
     audioParts.reduce((duration, a) => duration + a.duration, 0) * 1000

--- a/src/export-book-markdown.ts
+++ b/src/export-book-markdown.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import type { BookMetadata, ContentChunk } from './types'
-import { assert, getEnv, readJsonFile } from './utils'
+import { assert, getBookFilenameBase, getEnv, readJsonFile } from './utils'
 
 async function main() {
   const asin = getEnv('ASIN')
@@ -85,7 +85,10 @@ ${text}`
     index = nextIndex
   }
 
-  await fs.writeFile(path.join(outDir, 'book.md'), output)
+  await fs.writeFile(
+    path.join(outDir, `${getBookFilenameBase(metadata.meta)}.md`),
+    output
+  )
   console.log(output)
 }
 

--- a/src/export-book-pdf.ts
+++ b/src/export-book-pdf.ts
@@ -7,7 +7,7 @@ import path from 'node:path'
 import PDFDocument from 'pdfkit'
 
 import type { BookMetadata, ContentChunk } from './types'
-import { assert, getEnv } from './utils'
+import { assert, getBookFilenameBase, getEnv } from './utils'
 
 async function main() {
   const asin = getEnv('ASIN')
@@ -36,7 +36,11 @@ async function main() {
       Author: authors.join(', ')
     }
   })
-  const stream = doc.pipe(fs.createWriteStream(path.join(outDir, 'book.pdf')))
+  const stream = doc.pipe(
+    fs.createWriteStream(
+      path.join(outDir, `${getBookFilenameBase(metadata.meta)}.pdf`)
+    )
+  )
 
   const fontSize = 12
 

--- a/src/extract-kindle-book.ts
+++ b/src/extract-kindle-book.ts
@@ -12,6 +12,7 @@ import { chromium } from 'patchright'
 import sharp from 'sharp'
 
 import type {
+  AmazonBookMeta,
   AmazonRenderLocationMap,
   AmazonRenderToc,
   AmazonRenderTocItem,
@@ -175,11 +176,13 @@ async function main() {
             result.locationMap = locationMap
 
             for (const navUnit of result.locationMap.navigationUnit) {
-              navUnit.page = Number.parseInt(navUnit.label, 10)
-              assert(
-                !Number.isNaN(navUnit.page),
-                `invalid locationMap page number: ${navUnit.label}`
-              )
+              // Front-matter nav units are often labeled with roman numerals
+              // (e.g. "i", "ii", "iii") instead of page numbers; leave those
+              // unset rather than treating them as a fatal error.
+              const parsedPage = Number.parseInt(navUnit.label, 10)
+              if (!Number.isNaN(parsedPage)) {
+                navUnit.page = parsedPage
+              }
             }
           }
 
@@ -211,7 +214,9 @@ async function main() {
           // console.warn('toc', toc)
         }
       }
-    } catch {}
+    } catch (err) {
+      console.warn('error processing response', response.url(), err)
+    }
   })
 
   // Only used for the 'blob' render method
@@ -335,22 +340,89 @@ async function main() {
     await delay(500)
   }
 
-  async function goToPage(pageNumber: number) {
-    await page.locator('#reader-header').hover({ force: true })
-    await delay(200)
-    await page.locator('ion-button[aria-label="Reader menu"]').click()
-    await delay(500)
-    await page
-      .locator('ion-item[role="listitem"]', { hasText: 'Go to Page' })
-      .click()
-    await page
-      .locator('ion-modal input[placeholder="page number"]')
-      .fill(`${pageNumber}`)
-    // await page.locator('ion-modal button', { hasText: 'Go' }).click()
-    await page
-      .locator('ion-modal ion-button[item-i-d="go-to-modal-go-button"]')
-      .click()
-    await delay(500)
+  async function scrapeBookMetaFallback() {
+    const metaPage = await context.newPage()
+    try {
+      await metaPage.goto(`https://www.amazon.com/dp/${asin}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 30_000
+      })
+
+      const title = (
+        await metaPage.locator('#productTitle').first().textContent()
+      )?.trim()
+
+      const authorList = await metaPage
+        .locator('#bylineInfo .author a, .author a')
+        .allTextContents()
+        .then((authors) => authors.map((a) => a.trim()).filter(Boolean))
+
+      assert(title, `unable to scrape title for asin: ${asin}`)
+
+      return {
+        asin,
+        title,
+        authorList,
+        startPosition: result.nav.startPosition,
+        endPosition: result.nav.endPosition
+      } as AmazonBookMeta
+    } finally {
+      await metaPage.close()
+    }
+  }
+
+  // Clicks the reader's next-page chevron and waits for the rendered page
+  // image to change. Amazon's "Go to Page" menu item has proven unreliable
+  // across UI revisions, so this chevron click is the only navigation
+  // mechanism this script depends on.
+  async function advanceOnePage(prevSrc: string): Promise<boolean> {
+    let retries = 0
+
+    do {
+      // This delay seems to help speed up the navigation process, possibly due
+      // to the navigation chevron needing time to settle.
+      await delay(100)
+
+      let navigationTimeout = 10_000
+      try {
+        await page
+          .locator('.kr-chevron-container-right')
+          .click({ timeout: 5000 })
+      } catch (err: any) {
+        console.warn('unable to click next page button', err.message)
+        navigationTimeout = 1000
+      }
+
+      const navigatedToNextPage = await pRace<boolean | undefined>((signal) => [
+        (async () => {
+          while (!signal.aborted) {
+            const newSrc = await page
+              .locator(krRendererMainImageSelector)
+              .getAttribute('src')
+
+            if (newSrc && newSrc !== prevSrc) {
+              // Successfully navigated to the next page
+              return true
+            }
+
+            await delay(10)
+          }
+
+          return false
+        })(),
+
+        delay(navigationTimeout, { signal })
+      ])
+
+      if (navigatedToNextPage) {
+        return true
+      }
+
+      if (++retries >= 30) {
+        console.warn('unable to navigate to next page; giving up')
+        return false
+      }
+    } while (true)
   }
 
   async function getPageNav() {
@@ -416,7 +488,9 @@ async function main() {
     for (const { startPosition, page } of result.locationMap.navigationUnit) {
       if (startPosition > position) break
 
-      resultPage = page
+      if (page !== undefined) {
+        resultPage = page
+      }
     }
 
     return resultPage
@@ -435,13 +509,23 @@ async function main() {
       )
     })
 
-  // Record the initial page navigation so we can reset back to it later
-  const initialPageNav = await getPageNav()
-
   // At this point, we should have recorded all the base book metadata from the
-  // initial network requests.
-  assert(result.info, 'expected book info to be initialized')
-  assert(result.meta, 'expected book meta to be initialized')
+  // initial network requests. Amazon has, at various points, stopped firing
+  // the `startReading` / `YJmetadata.jsonp` requests this depends on for some
+  // accounts/books, so fall back to scraping the public product page for
+  // title/author if the network-derived metadata never showed up.
+  if (!result.info) {
+    console.warn(
+      'book info was not captured from network responses (Amazon may have changed their API); continuing without it since nothing downstream requires it'
+    )
+  }
+
+  if (!result.meta) {
+    console.warn(
+      'book meta was not captured from network responses; falling back to scraping the Amazon product page for title/author'
+    )
+    result.meta = await scrapeBookMetaFallback()
+  }
   assert(result.toc?.length, 'expected book toc to be initialized')
   assert(result.locationMap, 'expected book location map to be initialized')
 
@@ -474,8 +558,21 @@ async function main() {
     .length
   await writeResultMetadata()
 
-  // Navigate to the first content page of the book
-  await goToPage(result.nav.startContentPage)
+  // Navigate to the first content page of the book by clicking through with
+  // the next-page chevron (more reliable than Amazon's "Go to Page" menu).
+  console.warn(
+    `advancing to start of content (page ${result.nav.startContentPage})...`
+  )
+  for (;;) {
+    const pageNav = await getPageNav()
+    if ((pageNav?.page ?? 0) >= result.nav.startContentPage) break
+
+    const src = (await page
+      .locator(krRendererMainImageSelector)
+      .getAttribute('src'))!
+    const advanced = await advanceOnePage(src)
+    if (!advanced) break
+  }
 
   let done = false
   console.warn(
@@ -566,66 +663,15 @@ async function main() {
     console.warn(pageChunk)
     await writeResultMetadata()
 
-    let retries = 0
-
-    do {
-      // This delay seems to help speed up the navigation process, possibly due
-      // to the navigation chevron needing time to settle.
-      await delay(100)
-
-      let navigationTimeout = 10_000
-      try {
-        // await page.keyboard.press('ArrowRight')
-        await page
-          .locator('.kr-chevron-container-right')
-          .click({ timeout: 5000 })
-      } catch (err: any) {
-        console.warn('unable to click next page button', err.message, pageNav)
-        navigationTimeout = 1000
-      }
-
-      const navigatedToNextPage = await pRace<boolean | undefined>((signal) => [
-        (async () => {
-          while (!signal.aborted) {
-            const newSrc = await page
-              .locator(krRendererMainImageSelector)
-              .getAttribute('src')
-
-            if (newSrc && newSrc !== src) {
-              // Successfully navigated to the next page
-              return true
-            }
-
-            await delay(10)
-          }
-
-          return false
-        })(),
-
-        delay(navigationTimeout, { signal })
-      ])
-
-      if (navigatedToNextPage) {
-        break
-      }
-
-      if (++retries >= 30) {
-        console.warn('unable to navigate to next page; breaking...', pageNav)
-        done = true
-        break
-      }
-    } while (true)
+    const advanced = await advanceOnePage(src)
+    if (!advanced) {
+      done = true
+    }
   } while (!done)
 
   await writeResultMetadata()
   console.log()
   console.log(metadataPath)
-
-  if (initialPageNav?.page !== undefined) {
-    console.warn(`resetting back to initial page ${initialPageNav.page}...`)
-    // Reset back to the initial page
-    await goToPage(initialPageNav.page)
-  }
 
   await context.close()
   await context.browser()?.close()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -201,3 +201,26 @@ export function normalizeBookMetadata(
 ): Partial<BookMetadata> {
   return sortKeys(book, { compare: bookMetadataFieldComparator })
 }
+
+/** e.g. { title: 'Get Signed: Find an Agent...', authorList: ['Lucinda Halpern'] } -> 'Halpern_GetSigned' */
+export function getBookFilenameBase(meta: {
+  title: string
+  authorList: string[]
+}): string {
+  const lastName =
+    meta.authorList[0]
+      ?.trim()
+      .split(/\s+/)
+      .pop()
+      ?.replaceAll(/[^\p{L}\p{N}]/gu, '') || 'UnknownAuthor'
+
+  const mainTitle = meta.title.split(':')[0]!
+  const titleSlug =
+    mainTitle
+      .replaceAll(/[^\p{L}\p{N}\s]/gu, '')
+      .split(/\s+/)
+      .filter(Boolean)
+      .join('') || 'UnknownTitle'
+
+  return `${lastName}_${titleSlug}`
+}


### PR DESCRIPTION
## Summary

- Exported files are currently all named identically (`book.md`, `book.pdf`, `audiobook.mp3`) regardless of which book was exported, which makes it easy to lose track of output across multiple books since they all land in different `out/<asin>/` dirs but share the same generic basename.
- Adds `getBookFilenameBase(meta)` to `utils.ts`, deriving e.g. `Halpern_GetSigned` from the author's last name and the main title (subtitle after the first colon dropped, non-alphanumeric characters stripped).
- Wired into `export-book-markdown.ts`, `export-book-pdf.ts`, and `export-book-audio.ts`.

Independent of #36 (the reader API fixes) — happy to rebase/squash however is preferred if both land.

## Test plan

- [x] `pnpm test:typecheck` passes
- [x] Ran markdown + PDF export against a real book, confirmed output is named e.g. `Halpern_GetSigned.md` / `Halpern_GetSigned.pdf`