### PR TITLE
feat: embed real cover art in PDF export

### DIFF
--- a/src/export-book-audio.ts
+++ b/src/export-book-audio.ts
@@ -15,6 +15,7 @@ import {
   assert,
   ffmpegOnProgress,
   fileExists,
+  getBookFilenameBase,
   getEnv,
   hashObject,
   readJsonFile
@@ -254,7 +255,10 @@ ${text}`.split('\n\n')
     .map((a) => `file ${path.basename(a.audioFilePath)}`)
     .join('\n')
   await fs.writeFile(audioConcatInputFilePath, audioConcatInput)
-  const audiobookOutputFilePath = path.join(ttsOutDir, 'audiobook.mp3')
+  const audiobookOutputFilePath = path.join(
+    ttsOutDir,
+    `${getBookFilenameBase(metadata.meta)}.mp3`
+  )
 
   const expectedDurationMs =
     audioParts.reduce((duration, a) => duration + a.duration, 0) * 1000

--- a/src/export-book-markdown.ts
+++ b/src/export-book-markdown.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import type { BookMetadata, ContentChunk } from './types'
-import { assert, getEnv, readJsonFile } from './utils'
+import { assert, getBookFilenameBase, getEnv, readJsonFile } from './utils'
 
 async function main() {
   const asin = getEnv('ASIN')
@@ -85,7 +85,10 @@ ${text}`
     index = nextIndex
   }
 
-  await fs.writeFile(path.join(outDir, 'book.md'), output)
+  await fs.writeFile(
+    path.join(outDir, `${getBookFilenameBase(metadata.meta)}.md`),
+    output
+  )
   console.log(output)
 }
 

--- a/src/export-book-pdf.ts
+++ b/src/export-book-pdf.ts
@@ -46,19 +46,28 @@ async function main() {
 
   const renderTitlePage = () => {
     ;(doc as any).outline.addItem('Title Page')
-    doc.fontSize(48)
-    doc.y = doc.page.height / 2 - doc.heightOfString(title) / 2
-    doc.text(title, { align: 'center' })
-    const w = doc.widthOfString(title)
 
-    const byline = `By ${authors.join(',\n')}`
+    if (metadata.meta.cover && fs.existsSync(metadata.meta.cover)) {
+      doc.image(metadata.meta.cover, {
+        fit: [doc.page.width - 72, doc.page.height - 72],
+        align: 'center',
+        valign: 'center'
+      })
+    } else {
+      doc.fontSize(48)
+      doc.y = doc.page.height / 2 - doc.heightOfString(title) / 2
+      doc.text(title, { align: 'center' })
+      const w = doc.widthOfString(title)
 
-    doc.fontSize(20)
-    doc.y -= doc.heightOfString(byline) / 2
-    doc.text(byline, {
-      align: 'center',
-      indent: w - doc.widthOfString(byline)
-    })
+      const byline = `By ${authors.join(',\n')}`
+
+      doc.fontSize(20)
+      doc.y -= doc.heightOfString(byline) / 2
+      doc.text(byline, {
+        align: 'center',
+        indent: w - doc.widthOfString(byline)
+      })
+    }
 
     doc.addPage()
     doc.fontSize(fontSize)

--- a/src/export-book-pdf.ts
+++ b/src/export-book-pdf.ts
@@ -7,7 +7,7 @@ import path from 'node:path'
 import PDFDocument from 'pdfkit'
 
 import type { BookMetadata, ContentChunk } from './types'
-import { assert, getEnv } from './utils'
+import { assert, getBookFilenameBase, getEnv } from './utils'
 
 async function main() {
   const asin = getEnv('ASIN')
@@ -36,7 +36,11 @@ async function main() {
       Author: authors.join(', ')
     }
   })
-  const stream = doc.pipe(fs.createWriteStream(path.join(outDir, 'book.pdf')))
+  const stream = doc.pipe(
+    fs.createWriteStream(
+      path.join(outDir, `${getBookFilenameBase(metadata.meta)}.pdf`)
+    )
+  )
 
   const fontSize = 12
 

--- a/src/extract-kindle-book.ts
+++ b/src/extract-kindle-book.ts
@@ -369,10 +369,14 @@ async function main() {
 
       assert(title, `unable to scrape title for asin: ${asin}`)
 
+      /* eslint-disable unicorn/prefer-dom-node-dataset -- this is a
+         Playwright Locator, not a DOM node; it has no `.dataset` */
       const coverImageUrl = await metaPage
         .locator('#landingImage, #imgBlkFront')
-        .first().dataset.oldHires
+        .first()
+        .getAttribute('data-old-hires')
         .catch(() => null)
+      /* eslint-enable unicorn/prefer-dom-node-dataset */
 
       let cover = ''
       if (coverImageUrl) {

--- a/src/extract-kindle-book.ts
+++ b/src/extract-kindle-book.ts
@@ -22,6 +22,7 @@ import type {
 import { parsePageNav, parseTocItems } from './playwright-utils'
 import {
   assert,
+  deromanize,
   extractTar,
   getEnv,
   hashObject,
@@ -30,6 +31,15 @@ import {
   parseJsonpResponse,
   tryReadJsonFile
 } from './utils'
+
+// Front-matter pages are labeled with roman numerals (e.g. "Page vii of
+// 183") rather than the arabic page numbers the body uses, and the body
+// restarts its own arabic count at 1 once front matter ends (a common print
+// convention). To keep the two from colliding while still sorting correctly
+// (roman numerals increase the same direction as arabic page numbers do),
+// front-matter pages are offset below zero rather than negated -- negating
+// would reverse their ordering relative to each other.
+const FRONT_MATTER_PAGE_OFFSET = -1000
 
 // Block amazon analytics requests
 // (not strictly necessary, but adblockers do this by default anyway and it
@@ -176,12 +186,12 @@ async function main() {
             result.locationMap = locationMap
 
             for (const navUnit of result.locationMap.navigationUnit) {
-              // Front-matter nav units are often labeled with roman numerals
-              // (e.g. "i", "ii", "iii") instead of page numbers; leave those
-              // unset rather than treating them as a fatal error.
               const parsedPage = Number.parseInt(navUnit.label, 10)
               if (!Number.isNaN(parsedPage)) {
                 navUnit.page = parsedPage
+              } else if (/^[ivxlcdm]+$/i.test(navUnit.label)) {
+                navUnit.page =
+                  FRONT_MATTER_PAGE_OFFSET + deromanize(navUnit.label)
               }
             }
           }
@@ -359,10 +369,28 @@ async function main() {
 
       assert(title, `unable to scrape title for asin: ${asin}`)
 
+      const coverImageUrl = await metaPage
+        .locator('#landingImage, #imgBlkFront')
+        .first().dataset.oldHires
+        .catch(() => null)
+
+      let cover = ''
+      if (coverImageUrl) {
+        try {
+          const res = await metaPage.request.get(coverImageUrl)
+          const coverPath = path.join(outDir, 'cover.jpg')
+          await fs.writeFile(coverPath, await res.body())
+          cover = coverPath
+        } catch (err: any) {
+          console.warn('unable to download cover image', err.message)
+        }
+      }
+
       return {
         asin,
         title,
         authorList,
+        cover,
         startPosition: result.nav.startPosition,
         endPosition: result.nav.endPosition
       } as AmazonBookMeta
@@ -371,11 +399,14 @@ async function main() {
     }
   }
 
-  // Clicks the reader's next-page chevron and waits for the rendered page
-  // image to change. Amazon's "Go to Page" menu item has proven unreliable
-  // across UI revisions, so this chevron click is the only navigation
-  // mechanism this script depends on.
-  async function advanceOnePage(prevSrc: string): Promise<boolean> {
+  // Clicks the reader's next/prev-page chevron and waits for the rendered
+  // page image to change. Amazon's "Go to Page" menu item has proven
+  // unreliable across UI revisions, so chevron clicks are the only
+  // navigation mechanism this script depends on.
+  async function clickChevron(
+    direction: 'left' | 'right',
+    prevSrc: string
+  ): Promise<boolean> {
     let retries = 0
 
     do {
@@ -386,10 +417,10 @@ async function main() {
       let navigationTimeout = 10_000
       try {
         await page
-          .locator('.kr-chevron-container-right')
+          .locator(`.kr-chevron-container-${direction}`)
           .click({ timeout: 5000 })
       } catch (err: any) {
-        console.warn('unable to click next page button', err.message)
+        console.warn(`unable to click ${direction} page button`, err.message)
         navigationTimeout = 1000
       }
 
@@ -419,10 +450,30 @@ async function main() {
       }
 
       if (++retries >= 30) {
-        console.warn('unable to navigate to next page; giving up')
+        console.warn(`unable to navigate ${direction}; giving up`)
         return false
       }
     } while (true)
+  }
+
+  async function advanceOnePage(prevSrc: string): Promise<boolean> {
+    return clickChevron('right', prevSrc)
+  }
+
+  // Amazon syncs "last read position" server-side per account (not per local
+  // browser profile), so a freshly authenticated session can resume mid-book
+  // instead of at the true first page. Click backward until the page image
+  // stops changing, which means we've hit the actual beginning.
+  async function retreatToStart(): Promise<void> {
+    for (;;) {
+      const src = await page
+        .locator(krRendererMainImageSelector)
+        .getAttribute('src')
+      if (!src) break
+
+      const retreated = await clickChevron('left', src)
+      if (!retreated) break
+    }
   }
 
   async function getPageNav() {
@@ -482,7 +533,12 @@ async function main() {
   function getPageForPosition(position: number): number {
     if (!result.locationMap) return -1
 
-    let resultPage = 1
+    // Positions before the first labeled nav unit (e.g. an unlabeled cover
+    // page preceding front-matter roman numeral "i") belong with that first
+    // unit's page, not a hardcoded default -- otherwise they'd fall back to
+    // a value indistinguishable from a real body page number.
+    let resultPage =
+      result.locationMap.navigationUnit[0]?.page ?? FRONT_MATTER_PAGE_OFFSET
 
     // TODO: this is O(n) but we can do better
     for (const { startPosition, page } of result.locationMap.navigationUnit) {
@@ -558,36 +614,43 @@ async function main() {
     .length
   await writeResultMetadata()
 
-  // Navigate to the first content page of the book by clicking through with
-  // the next-page chevron (more reliable than Amazon's "Go to Page" menu).
-  console.warn(
-    `advancing to start of content (page ${result.nav.startContentPage})...`
-  )
-  for (;;) {
-    const pageNav = await getPageNav()
-    if ((pageNav?.page ?? 0) >= result.nav.startContentPage) break
-
-    const src = (await page
-      .locator(krRendererMainImageSelector)
-      .getAttribute('src'))!
-    const advanced = await advanceOnePage(src)
-    if (!advanced) break
-  }
+  console.warn('rewinding to the true first page...')
+  await retreatToStart()
 
   let done = false
   console.warn(
     `\nreading ${result.nav.totalNumContentPages} content pages out of ${result.nav.totalNumPages} total pages...\n`
   )
 
-  // Loop through each page of the book
+  // Loop through each page of the book. Front-matter pages report a roman
+  // numeral in the reader's footer (e.g. "Page vii of 183") rather than an
+  // arabic page number; signedPage offsets those below zero (see
+  // FRONT_MATTER_PAGE_OFFSET) so they don't collide with the body's own
+  // arabic count, which restarts at 1 once front matter ends.
   do {
     const pageNav = await getPageNav()
+    const signedPage =
+      pageNav?.page ??
+      (pageNav?.romanPage !== undefined
+        ? FRONT_MATTER_PAGE_OFFSET + pageNav.romanPage
+        : undefined)
 
-    if (pageNav?.page === undefined) {
+    if (signedPage === undefined) {
+      if (result.pages.length === 0) {
+        // The reader hasn't finished computing real page labels yet (shows
+        // a generic "Location N of M" instead) -- nudge it forward once and
+        // retry rather than giving up on the very first page.
+        const src = (await page
+          .locator(krRendererMainImageSelector)
+          .getAttribute('src'))!
+        await advanceOnePage(src)
+        continue
+      }
+
       break
     }
 
-    if (pageNav.page > result.nav.totalNumContentPages) {
+    if (signedPage > 0 && signedPage > result.nav.totalNumContentPages) {
       break
     }
 
@@ -621,7 +684,7 @@ async function main() {
 
       assert(
         blob,
-        `no blob found for src: ${src} (index ${index}; page ${pageNav.page})`
+        `no blob found for src: ${src} (index ${index}; page ${signedPage})`
       )
 
       const rawRenderedImage = Buffer.from(blob.base64, 'base64')
@@ -642,21 +705,22 @@ async function main() {
 
     assert(
       renderedPageImageBuffer,
-      `no buffer found for src: ${src} (index ${index}; page ${pageNav.page})`
+      `no buffer found for src: ${src} (index ${index}; page ${signedPage})`
     )
 
     const screenshotPath = path.join(
       pageScreenshotsDir,
       `${index}`.padStart(pageNumberPaddingAmount, '0') +
         '-' +
-        `${pageNav.page}`.padStart(pageNumberPaddingAmount, '0') +
+        (signedPage < 0 ? '-' : '') +
+        `${Math.abs(signedPage)}`.padStart(pageNumberPaddingAmount, '0') +
         '.png'
     )
 
     await fs.writeFile(screenshotPath, renderedPageImageBuffer)
     const pageChunk = {
       index,
-      page: pageNav.page,
+      page: signedPage,
       screenshot: screenshotPath
     }
     result.pages.push(pageChunk)

--- a/src/extract-kindle-book.ts
+++ b/src/extract-kindle-book.ts
@@ -12,6 +12,7 @@ import { chromium } from 'patchright'
 import sharp from 'sharp'
 
 import type {
+  AmazonBookMeta,
   AmazonRenderLocationMap,
   AmazonRenderToc,
   AmazonRenderTocItem,
@@ -175,11 +176,13 @@ async function main() {
             result.locationMap = locationMap
 
             for (const navUnit of result.locationMap.navigationUnit) {
-              navUnit.page = Number.parseInt(navUnit.label, 10)
-              assert(
-                !Number.isNaN(navUnit.page),
-                `invalid locationMap page number: ${navUnit.label}`
-              )
+              // Front-matter nav units are often labeled with roman numerals
+              // (e.g. "i", "ii", "iii") instead of page numbers; leave those
+              // unset rather than treating them as a fatal error.
+              const parsedPage = Number.parseInt(navUnit.label, 10)
+              if (!Number.isNaN(parsedPage)) {
+                navUnit.page = parsedPage
+              }
             }
           }
 
@@ -211,7 +214,9 @@ async function main() {
           // console.warn('toc', toc)
         }
       }
-    } catch {}
+    } catch (err) {
+      console.warn('error processing response', response.url(), err)
+    }
   })
 
   // Only used for the 'blob' render method
@@ -335,22 +340,89 @@ async function main() {
     await delay(500)
   }
 
-  async function goToPage(pageNumber: number) {
-    await page.locator('#reader-header').hover({ force: true })
-    await delay(200)
-    await page.locator('ion-button[aria-label="Reader menu"]').click()
-    await delay(500)
-    await page
-      .locator('ion-item[role="listitem"]', { hasText: 'Go to Page' })
-      .click()
-    await page
-      .locator('ion-modal input[placeholder="page number"]')
-      .fill(`${pageNumber}`)
-    // await page.locator('ion-modal button', { hasText: 'Go' }).click()
-    await page
-      .locator('ion-modal ion-button[item-i-d="go-to-modal-go-button"]')
-      .click()
-    await delay(500)
+  async function scrapeBookMetaFallback() {
+    const metaPage = await context.newPage()
+    try {
+      await metaPage.goto(`https://www.amazon.com/dp/${asin}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 30_000
+      })
+
+      const title = (
+        await metaPage.locator('#productTitle').first().textContent()
+      )?.trim()
+
+      const authorList = await metaPage
+        .locator('#bylineInfo .author a, .author a')
+        .allTextContents()
+        .then((authors) => authors.map((a) => a.trim()).filter(Boolean))
+
+      assert(title, `unable to scrape title for asin: ${asin}`)
+
+      return {
+        asin,
+        title,
+        authorList,
+        startPosition: result.nav.startPosition,
+        endPosition: result.nav.endPosition
+      } as AmazonBookMeta
+    } finally {
+      await metaPage.close()
+    }
+  }
+
+  // Clicks the reader's next-page chevron and waits for the rendered page
+  // image to change. Amazon's "Go to Page" menu item has proven unreliable
+  // across UI revisions, so this chevron click is the only navigation
+  // mechanism this script depends on.
+  async function advanceOnePage(prevSrc: string): Promise<boolean> {
+    let retries = 0
+
+    do {
+      // This delay seems to help speed up the navigation process, possibly due
+      // to the navigation chevron needing time to settle.
+      await delay(100)
+
+      let navigationTimeout = 10_000
+      try {
+        await page
+          .locator('.kr-chevron-container-right')
+          .click({ timeout: 5000 })
+      } catch (err: any) {
+        console.warn('unable to click next page button', err.message)
+        navigationTimeout = 1000
+      }
+
+      const navigatedToNextPage = await pRace<boolean | undefined>((signal) => [
+        (async () => {
+          while (!signal.aborted) {
+            const newSrc = await page
+              .locator(krRendererMainImageSelector)
+              .getAttribute('src')
+
+            if (newSrc && newSrc !== prevSrc) {
+              // Successfully navigated to the next page
+              return true
+            }
+
+            await delay(10)
+          }
+
+          return false
+        })(),
+
+        delay(navigationTimeout, { signal })
+      ])
+
+      if (navigatedToNextPage) {
+        return true
+      }
+
+      if (++retries >= 30) {
+        console.warn('unable to navigate to next page; giving up')
+        return false
+      }
+    } while (true)
   }
 
   async function getPageNav() {
@@ -416,7 +488,9 @@ async function main() {
     for (const { startPosition, page } of result.locationMap.navigationUnit) {
       if (startPosition > position) break
 
-      resultPage = page
+      if (page !== undefined) {
+        resultPage = page
+      }
     }
 
     return resultPage
@@ -435,13 +509,23 @@ async function main() {
       )
     })
 
-  // Record the initial page navigation so we can reset back to it later
-  const initialPageNav = await getPageNav()
-
   // At this point, we should have recorded all the base book metadata from the
-  // initial network requests.
-  assert(result.info, 'expected book info to be initialized')
-  assert(result.meta, 'expected book meta to be initialized')
+  // initial network requests. Amazon has, at various points, stopped firing
+  // the `startReading` / `YJmetadata.jsonp` requests this depends on for some
+  // accounts/books, so fall back to scraping the public product page for
+  // title/author if the network-derived metadata never showed up.
+  if (!result.info) {
+    console.warn(
+      'book info was not captured from network responses (Amazon may have changed their API); continuing without it since nothing downstream requires it'
+    )
+  }
+
+  if (!result.meta) {
+    console.warn(
+      'book meta was not captured from network responses; falling back to scraping the Amazon product page for title/author'
+    )
+    result.meta = await scrapeBookMetaFallback()
+  }
   assert(result.toc?.length, 'expected book toc to be initialized')
   assert(result.locationMap, 'expected book location map to be initialized')
 
@@ -474,8 +558,21 @@ async function main() {
     .length
   await writeResultMetadata()
 
-  // Navigate to the first content page of the book
-  await goToPage(result.nav.startContentPage)
+  // Navigate to the first content page of the book by clicking through with
+  // the next-page chevron (more reliable than Amazon's "Go to Page" menu).
+  console.warn(
+    `advancing to start of content (page ${result.nav.startContentPage})...`
+  )
+  for (;;) {
+    const pageNav = await getPageNav()
+    if ((pageNav?.page ?? 0) >= result.nav.startContentPage) break
+
+    const src = (await page
+      .locator(krRendererMainImageSelector)
+      .getAttribute('src'))!
+    const advanced = await advanceOnePage(src)
+    if (!advanced) break
+  }
 
   let done = false
   console.warn(
@@ -566,66 +663,15 @@ async function main() {
     console.warn(pageChunk)
     await writeResultMetadata()
 
-    let retries = 0
-
-    do {
-      // This delay seems to help speed up the navigation process, possibly due
-      // to the navigation chevron needing time to settle.
-      await delay(100)
-
-      let navigationTimeout = 10_000
-      try {
-        // await page.keyboard.press('ArrowRight')
-        await page
-          .locator('.kr-chevron-container-right')
-          .click({ timeout: 5000 })
-      } catch (err: any) {
-        console.warn('unable to click next page button', err.message, pageNav)
-        navigationTimeout = 1000
-      }
-
-      const navigatedToNextPage = await pRace<boolean | undefined>((signal) => [
-        (async () => {
-          while (!signal.aborted) {
-            const newSrc = await page
-              .locator(krRendererMainImageSelector)
-              .getAttribute('src')
-
-            if (newSrc && newSrc !== src) {
-              // Successfully navigated to the next page
-              return true
-            }
-
-            await delay(10)
-          }
-
-          return false
-        })(),
-
-        delay(navigationTimeout, { signal })
-      ])
-
-      if (navigatedToNextPage) {
-        break
-      }
-
-      if (++retries >= 30) {
-        console.warn('unable to navigate to next page; breaking...', pageNav)
-        done = true
-        break
-      }
-    } while (true)
+    const advanced = await advanceOnePage(src)
+    if (!advanced) {
+      done = true
+    }
   } while (!done)
 
   await writeResultMetadata()
   console.log()
   console.log(metadataPath)
-
-  if (initialPageNav?.page !== undefined) {
-    console.warn(`resetting back to initial page ${initialPageNav.page}...`)
-    // Reset back to the initial page
-    await goToPage(initialPageNav.page)
-  }
 
   await context.close()
   await context.browser()?.close()

--- a/src/playwright-utils.ts
+++ b/src/playwright-utils.ts
@@ -33,16 +33,16 @@ export function parsePageNav(text: string | null): PageNav | undefined {
   }
 
   {
-    // Parse locations which use roman numerals
+    // Parse front-matter page numbers, which use roman numerals
     const match = text?.match(/page\s+([cdilmvx]+)\s+of\s+(\d+)/i)
     if (match) {
-      const location = deromanize(match?.[1]!)
+      const romanPage = deromanize(match?.[1]!)
       const total = Number.parseInt(match?.[2]!)
-      if (Number.isNaN(location) || Number.isNaN(total)) {
+      if (Number.isNaN(romanPage) || Number.isNaN(total)) {
         return undefined
       }
 
-      return { location, total }
+      return { romanPage, total }
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,13 @@ export interface ContentChunk {
 }
 
 export interface PageNav {
+  /** Arabic page number, e.g. from footer text "Page 7 of 183" */
   page?: number
+  /** Front-matter page number deromanized from footer text like "Page vii of 183" */
+  romanPage?: number
+  /** Generic progress counter from footer text "Location 123 of 2296", shown only
+   * transiently before the reader has computed real page numbers -- not a stable
+   * page identifier and shouldn't be used to key content. */
   location?: number
   total: number
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -201,3 +201,26 @@ export function normalizeBookMetadata(
 ): Partial<BookMetadata> {
   return sortKeys(book, { compare: bookMetadataFieldComparator })
 }
+
+/** e.g. { title: 'Get Signed: Find an Agent...', authorList: ['Lucinda Halpern'] } -> 'Halpern_GetSigned' */
+export function getBookFilenameBase(meta: {
+  title: string
+  authorList: string[]
+}): string {
+  const lastName =
+    meta.authorList[0]
+      ?.trim()
+      .split(/\s+/)
+      .pop()
+      ?.replaceAll(/[^\p{L}\p{N}]/gu, '') || 'UnknownAuthor'
+
+  const mainTitle = meta.title.split(':')[0]!
+  const titleSlug =
+    mainTitle
+      .replaceAll(/[^\p{L}\p{N}\s]/gu, '')
+      .split(/\s+/)
+      .filter(Boolean)
+      .join('') || 'UnknownTitle'
+
+  return `${lastName}_${titleSlug}`
+}


### PR DESCRIPTION
## Summary

Depends on #36 (front-matter fix, which adds cover art fetching to `extract-kindle-book.ts`'s metadata fallback).

- `extract-kindle-book.ts` now fetches the book's actual cover image from its Amazon product page (`data-old-hires` on the product image) and saves it to `<outDir>/cover.jpg`, recorded on `meta.cover`.
- `export-book-pdf.ts` uses it as a real cover page when available, instead of a plain text title/author page. Falls back to the old text rendering if no cover was captured.

## Test plan

- [x] `pnpm test:typecheck` passes
- [x] Ran PDF export against a real book, confirmed the cover page shows the actual full-color cover art